### PR TITLE
Restore guardrails and keep sensitive config in Secrets Manager

### DIFF
--- a/infrastructure/api-gateway.tf
+++ b/infrastructure/api-gateway.tf
@@ -14,8 +14,8 @@ resource "aws_apigatewayv2_authorizer" "jwt" {
   name = "${var.project_name}-jwt-authorizer-${var.environment}"
 
   jwt_configuration {
-    issuer   = var.jwt_issuer
-    audience = var.jwt_audience
+    issuer   = local.jwt_issuer_effective
+    audience = local.jwt_audience_effective
   }
 }
 
@@ -183,6 +183,11 @@ resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.http_api.id
   name        = "$default"
   auto_deploy = true
+
+  default_route_settings {
+    throttling_rate_limit  = var.api_throttle_rate_limit
+    throttling_burst_limit = var.api_throttle_burst_limit
+  }
 }
 
 resource "aws_lambda_permission" "allow_apigw_upload" {

--- a/infrastructure/bootstrap/README.md
+++ b/infrastructure/bootstrap/README.md
@@ -4,6 +4,7 @@ This stack creates:
 - S3 bucket for Terraform remote state
 - IAM user for Terraform deployment (`millerpic_tf` by default)
 - Inline custom policy with required deployment permissions
+- AWS Secrets Manager entry for sensitive app config (`jwt_issuer`, `jwt_audience`, `cost_alert_email`)
 
 ## Usage
 
@@ -24,9 +25,12 @@ Set-Location infrastructure/bootstrap
 & $terraformPath apply -var="bootstrap_profile=pandacloud"
 ```
 
+If you prefer `terraform.tfvars`, copy `terraform.tfvars.example` in this folder and fill in your values before apply.
+
 ## After Apply
 
 1. Create access keys for output user (`millerpic_tf` by default).
 2. Configure local AWS profile `millerpic_tf` with those keys.
 3. Create `infrastructure/backend.tf` using `suggested_backend_block` output from this bootstrap stack.
-4. Run Terraform for app infrastructure using the new deployer profile.
+4. Note `app_sensitive_config_secret_name` output; app infrastructure reads this secret by default naming convention (`<project>/<environment>/app-sensitive-config`) or via explicit override.
+5. Run Terraform for app infrastructure using the new deployer profile.

--- a/infrastructure/bootstrap/outputs.tf
+++ b/infrastructure/bootstrap/outputs.tf
@@ -13,6 +13,16 @@ output "terraform_deployer_user_name" {
   value       = aws_iam_user.terraform_deployer.name
 }
 
+output "app_sensitive_config_secret_name" {
+  description = "Secrets Manager name containing app sensitive config"
+  value       = aws_secretsmanager_secret.app_sensitive_config.name
+}
+
+output "app_sensitive_config_secret_arn" {
+  description = "Secrets Manager ARN containing app sensitive config"
+  value       = aws_secretsmanager_secret.app_sensitive_config.arn
+}
+
 output "suggested_backend_block" {
   description = "Suggested backend block to paste into infrastructure/backend.tf"
   value       = <<EOT

--- a/infrastructure/bootstrap/terraform.tfvars.example
+++ b/infrastructure/bootstrap/terraform.tfvars.example
@@ -1,5 +1,11 @@
 aws_region                  = "us-east-1"
 bootstrap_profile           = "pandacloud"
 project_name                = "millerpic"
+environment                 = "dev"
 state_bucket_prefix         = "millerpic-terraform-state"
 terraform_deployer_user_name = "millerpic_tf"
+
+# Sensitive app config stored in AWS Secrets Manager by this bootstrap stack.
+jwt_issuer                  = "https://accounts.google.com"
+jwt_audience                = ["replace-with-your-google-client-id.apps.googleusercontent.com"]
+cost_alert_email            = "replace-me@example.com"

--- a/infrastructure/bootstrap/variables.tf
+++ b/infrastructure/bootstrap/variables.tf
@@ -16,6 +16,12 @@ variable "project_name" {
   default     = "millerpic"
 }
 
+variable "environment" {
+  description = "Deployment environment name used in secret naming"
+  type        = string
+  default     = "dev"
+}
+
 variable "state_bucket_prefix" {
   description = "Prefix for Terraform state bucket"
   type        = string
@@ -26,4 +32,22 @@ variable "terraform_deployer_user_name" {
   description = "IAM user name for Terraform deployment operations"
   type        = string
   default     = "millerpic_tf"
+}
+
+variable "jwt_issuer" {
+  description = "JWT issuer URL stored in Secrets Manager for app infrastructure"
+  type        = string
+  default     = "https://accounts.google.com"
+}
+
+variable "jwt_audience" {
+  description = "JWT audiences stored in Secrets Manager for app infrastructure"
+  type        = list(string)
+  default     = []
+}
+
+variable "cost_alert_email" {
+  description = "Optional alert email stored in Secrets Manager"
+  type        = string
+  default     = ""
 }

--- a/infrastructure/cost-guardrails.tf
+++ b/infrastructure/cost-guardrails.tf
@@ -1,0 +1,192 @@
+locals {
+  lambda_alarm_functions = {
+    upload          = aws_lambda_function.upload.function_name
+    download        = aws_lambda_function.download.function_name
+    list            = aws_lambda_function.list.function_name
+    upload_complete = aws_lambda_function.upload_complete.function_name
+    patch_photo     = aws_lambda_function.patch_photo.function_name
+    delete          = aws_lambda_function.delete.function_name
+    trash           = aws_lambda_function.trash.function_name
+    hard_delete     = aws_lambda_function.hard_delete.function_name
+    search          = aws_lambda_function.search.function_name
+    get_photo       = aws_lambda_function.get_photo.function_name
+  }
+
+  alert_email               = local.cost_alert_email_effective
+  use_sns_alert_topic       = var.enable_cost_protection && var.enable_sns_alert_topic
+  budget_has_any_subscriber = local.alert_email != "" || local.use_sns_alert_topic
+  alarm_action_arns         = local.use_sns_alert_topic ? [aws_sns_topic.security_cost_alerts[0].arn] : []
+  budget_sns_topic_arns     = local.use_sns_alert_topic ? [aws_sns_topic.security_cost_alerts[0].arn] : []
+  budget_subscriber_emails  = local.alert_email != "" ? [local.alert_email] : []
+  budget_notifications = local.budget_has_any_subscriber ? [
+    {
+      notification_type = "ACTUAL"
+      threshold         = 100
+    },
+    {
+      notification_type = "FORECASTED"
+      threshold         = var.monthly_cost_forecast_alert_threshold_percent
+    }
+  ] : []
+}
+
+resource "aws_sns_topic" "security_cost_alerts" {
+  count = local.use_sns_alert_topic ? 1 : 0
+
+  name = "${var.project_name}-security-cost-alerts-${var.environment}"
+}
+
+resource "aws_sns_topic_subscription" "security_cost_alerts_email" {
+  count = local.use_sns_alert_topic && local.alert_email != "" ? 1 : 0
+
+  topic_arn = aws_sns_topic.security_cost_alerts[0].arn
+  protocol  = "email"
+  endpoint  = local.alert_email
+}
+
+resource "aws_budgets_budget" "monthly_account_budget" {
+  count = var.enable_cost_protection && var.enable_aws_budgets ? 1 : 0
+
+  name              = "${var.project_name}-${var.environment}-monthly-budget"
+  budget_type       = "COST"
+  limit_amount      = tostring(var.monthly_cost_budget_usd)
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start = "2026-01-01_00:00"
+
+  dynamic "notification" {
+    for_each = local.budget_notifications
+
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = notification.value.threshold
+      threshold_type             = "PERCENTAGE"
+      notification_type          = notification.value.notification_type
+      subscriber_sns_topic_arns  = local.budget_sns_topic_arns
+      subscriber_email_addresses = local.budget_subscriber_emails
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "billing_estimated_charges" {
+  count = var.enable_cost_protection && var.aws_region == "us-east-1" ? 1 : 0
+
+  alarm_name          = "${var.project_name}-${var.environment}-billing-estimated-charges"
+  alarm_description   = "Estimated AWS charges exceeded configured monthly budget threshold"
+  namespace           = "AWS/Billing"
+  metric_name         = "EstimatedCharges"
+  statistic           = "Maximum"
+  period              = 21600
+  evaluation_periods  = 1
+  threshold           = var.monthly_cost_budget_usd
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alarm_action_arns
+
+  dimensions = {
+    Currency = "USD"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_4xx" {
+  count = var.enable_cost_protection ? 1 : 0
+
+  alarm_name          = "${var.project_name}-${var.environment}-api-4xx-spike"
+  alarm_description   = "API Gateway 4xx count exceeded threshold"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "4xx"
+  statistic           = "Sum"
+  period              = var.alarm_period_seconds
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.api_4xx_alarm_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alarm_action_arns
+
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.http_api.id
+    Stage = aws_apigatewayv2_stage.default.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_5xx" {
+  count = var.enable_cost_protection ? 1 : 0
+
+  alarm_name          = "${var.project_name}-${var.environment}-api-5xx-spike"
+  alarm_description   = "API Gateway 5xx count exceeded threshold"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "5xx"
+  statistic           = "Sum"
+  period              = var.alarm_period_seconds
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.api_5xx_alarm_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alarm_action_arns
+
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.http_api.id
+    Stage = aws_apigatewayv2_stage.default.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_request_count" {
+  count = var.enable_cost_protection ? 1 : 0
+
+  alarm_name          = "${var.project_name}-${var.environment}-api-request-surge"
+  alarm_description   = "API Gateway request count exceeded threshold"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "Count"
+  statistic           = "Sum"
+  period              = var.alarm_period_seconds
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.api_request_count_alarm_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alarm_action_arns
+
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.http_api.id
+    Stage = aws_apigatewayv2_stage.default.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  for_each = var.enable_cost_protection ? local.lambda_alarm_functions : {}
+
+  alarm_name          = "${var.project_name}-${var.environment}-lambda-errors-${each.key}"
+  alarm_description   = "Lambda errors exceeded threshold for ${each.key}"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = var.alarm_period_seconds
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.lambda_errors_alarm_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alarm_action_arns
+
+  dimensions = {
+    FunctionName = each.value
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  for_each = var.enable_cost_protection ? local.lambda_alarm_functions : {}
+
+  alarm_name          = "${var.project_name}-${var.environment}-lambda-throttles-${each.key}"
+  alarm_description   = "Lambda throttles exceeded threshold for ${each.key}"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Throttles"
+  statistic           = "Sum"
+  period              = var.alarm_period_seconds
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.lambda_throttles_alarm_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alarm_action_arns
+
+  dimensions = {
+    FunctionName = each.value
+  }
+}

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -110,11 +110,12 @@ resource "aws_iam_role_policy_attachment" "app_policy_attach" {
 }
 
 resource "aws_lambda_function" "upload" {
-  function_name = "${var.project_name}-upload-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "upload.handler"
-  filename      = data.archive_file.upload.output_path
+  function_name                  = "${var.project_name}-upload-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "upload.handler"
+  filename                       = data.archive_file.upload.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.upload.output_base64sha256
 
@@ -127,28 +128,31 @@ resource "aws_lambda_function" "upload" {
 }
 
 resource "aws_lambda_function" "download" {
-  function_name = "${var.project_name}-download-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "download.handler"
-  filename      = data.archive_file.download.output_path
+  function_name                  = "${var.project_name}-download-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "download.handler"
+  filename                       = data.archive_file.download.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.download.output_base64sha256
 
   environment {
     variables = {
-      PHOTO_BUCKET = aws_s3_bucket.photos.bucket
-      PHOTOS_TABLE = aws_dynamodb_table.photos.name
+      PHOTO_BUCKET             = aws_s3_bucket.photos.bucket
+      PHOTOS_TABLE             = aws_dynamodb_table.photos.name
+      DOWNLOAD_URL_TTL_SECONDS = tostring(var.download_url_ttl_seconds)
     }
   }
 }
 
 resource "aws_lambda_function" "list" {
-  function_name = "${var.project_name}-list-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "list.handler"
-  filename      = data.archive_file.list.output_path
+  function_name                  = "${var.project_name}-list-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "list.handler"
+  filename                       = data.archive_file.list.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.list.output_base64sha256
 
@@ -161,11 +165,12 @@ resource "aws_lambda_function" "list" {
 }
 
 resource "aws_lambda_function" "upload_complete" {
-  function_name = "${var.project_name}-upload-complete-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "upload_complete.handler"
-  filename      = data.archive_file.upload_complete.output_path
+  function_name                  = "${var.project_name}-upload-complete-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "upload_complete.handler"
+  filename                       = data.archive_file.upload_complete.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.upload_complete.output_base64sha256
 
@@ -178,11 +183,12 @@ resource "aws_lambda_function" "upload_complete" {
 }
 
 resource "aws_lambda_function" "delete" {
-  function_name = "${var.project_name}-delete-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "delete.handler"
-  filename      = data.archive_file.delete.output_path
+  function_name                  = "${var.project_name}-delete-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "delete.handler"
+  filename                       = data.archive_file.delete.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.delete.output_base64sha256
 
@@ -195,11 +201,12 @@ resource "aws_lambda_function" "delete" {
 }
 
 resource "aws_lambda_function" "trash" {
-  function_name = "${var.project_name}-trash-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "trash.handler"
-  filename      = data.archive_file.trash.output_path
+  function_name                  = "${var.project_name}-trash-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "trash.handler"
+  filename                       = data.archive_file.trash.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.trash.output_base64sha256
 
@@ -212,11 +219,12 @@ resource "aws_lambda_function" "trash" {
 }
 
 resource "aws_lambda_function" "hard_delete" {
-  function_name = "${var.project_name}-hard-delete-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "hard_delete.handler"
-  filename      = data.archive_file.hard_delete.output_path
+  function_name                  = "${var.project_name}-hard-delete-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "hard_delete.handler"
+  filename                       = data.archive_file.hard_delete.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.hard_delete.output_base64sha256
 
@@ -229,11 +237,12 @@ resource "aws_lambda_function" "hard_delete" {
 }
 
 resource "aws_lambda_function" "patch_photo" {
-  function_name = "${var.project_name}-patch-photo-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "patch_photo.handler"
-  filename      = data.archive_file.patch_photo.output_path
+  function_name                  = "${var.project_name}-patch-photo-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "patch_photo.handler"
+  filename                       = data.archive_file.patch_photo.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.patch_photo.output_base64sha256
 
@@ -245,11 +254,12 @@ resource "aws_lambda_function" "patch_photo" {
 }
 
 resource "aws_lambda_function" "search" {
-  function_name = "${var.project_name}-search-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "search.handler"
-  filename      = data.archive_file.search.output_path
+  function_name                  = "${var.project_name}-search-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "search.handler"
+  filename                       = data.archive_file.search.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.search.output_base64sha256
 
@@ -261,11 +271,12 @@ resource "aws_lambda_function" "search" {
 }
 
 resource "aws_lambda_function" "get_photo" {
-  function_name = "${var.project_name}-get-photo-${var.environment}"
-  role          = aws_iam_role.lambda_exec.arn
-  runtime       = local.lambda_runtime
-  handler       = "get_photo.handler"
-  filename      = data.archive_file.get_photo.output_path
+  function_name                  = "${var.project_name}-get-photo-${var.environment}"
+  role                           = aws_iam_role.lambda_exec.arn
+  runtime                        = local.lambda_runtime
+  handler                        = "get_photo.handler"
+  filename                       = data.archive_file.get_photo.output_path
+  reserved_concurrent_executions = var.lambda_reserved_concurrency_per_function
 
   source_code_hash = data.archive_file.get_photo.output_base64sha256
 

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -1,0 +1,30 @@
+locals {
+  effective_sensitive_config_secret_name = trimspace(var.sensitive_config_secret_name) != "" ? var.sensitive_config_secret_name : "${var.project_name}/${var.environment}/app-sensitive-config"
+}
+
+data "aws_secretsmanager_secret" "app_sensitive_config" {
+  count = var.load_sensitive_config_from_secrets && var.enable_jwt_auth ? 1 : 0
+
+  name = local.effective_sensitive_config_secret_name
+}
+
+data "aws_secretsmanager_secret_version" "app_sensitive_config" {
+  count = var.load_sensitive_config_from_secrets && var.enable_jwt_auth ? 1 : 0
+
+  secret_id = data.aws_secretsmanager_secret.app_sensitive_config[0].id
+}
+
+locals {
+  app_sensitive_config = merge(
+    {
+      jwt_issuer       = var.jwt_issuer
+      jwt_audience     = var.jwt_audience
+      cost_alert_email = var.cost_alert_email
+    },
+    try(jsondecode(data.aws_secretsmanager_secret_version.app_sensitive_config[0].secret_string), {})
+  )
+
+  jwt_issuer_effective       = try(local.app_sensitive_config.jwt_issuer, var.jwt_issuer)
+  jwt_audience_effective     = try(local.app_sensitive_config.jwt_audience, var.jwt_audience)
+  cost_alert_email_effective = trimspace(try(local.app_sensitive_config.cost_alert_email, var.cost_alert_email))
+}

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -3,6 +3,31 @@ environment      = "dev"
 project_name     = "millerpic"
 s3_bucket_prefix = "millerpic-photos"
 
+enable_jwt_auth                   = true
+load_sensitive_config_from_secrets = true
+# Optional override when your bootstrap secret uses a custom name.
+# sensitive_config_secret_name = "millerpic/dev/app-sensitive-config"
+
+enable_cost_protection                        = true
+enable_sns_alert_topic                        = true
+enable_aws_budgets                            = true
+monthly_cost_budget_usd                       = 25
+monthly_cost_forecast_alert_threshold_percent = 80
+
+api_throttle_rate_limit  = 20
+api_throttle_burst_limit = 40
+
+lambda_reserved_concurrency_per_function = 10
+download_url_ttl_seconds                 = 900
+
+api_4xx_alarm_threshold           = 200
+api_5xx_alarm_threshold           = 20
+api_request_count_alarm_threshold = 5000
+lambda_errors_alarm_threshold     = 5
+lambda_throttles_alarm_threshold  = 1
+alarm_period_seconds              = 300
+alarm_evaluation_periods          = 1
+
 tags = {
   Project     = "MillerPic"
   Environment = "dev"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -46,6 +46,130 @@ variable "jwt_audience" {
   default     = ["millerpic"]
 }
 
+variable "load_sensitive_config_from_secrets" {
+  description = "Load JWT and other sensitive config from AWS Secrets Manager"
+  type        = bool
+  default     = true
+}
+
+variable "sensitive_config_secret_name" {
+  description = "Optional override for Secrets Manager name containing sensitive app config"
+  type        = string
+  default     = ""
+}
+
+variable "api_throttle_rate_limit" {
+  description = "Steady-state API Gateway requests per second across routes"
+  type        = number
+  default     = 20
+}
+
+variable "api_throttle_burst_limit" {
+  description = "API Gateway burst requests across routes"
+  type        = number
+  default     = 40
+}
+
+variable "lambda_reserved_concurrency_per_function" {
+  description = "Reserved concurrency cap per public Lambda function (-1 to disable)"
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.lambda_reserved_concurrency_per_function == -1 || var.lambda_reserved_concurrency_per_function >= 1
+    error_message = "lambda_reserved_concurrency_per_function must be -1 or >= 1."
+  }
+}
+
+variable "download_url_ttl_seconds" {
+  description = "Presigned download URL TTL in seconds"
+  type        = number
+  default     = 900
+
+  validation {
+    condition     = var.download_url_ttl_seconds >= 60 && var.download_url_ttl_seconds <= 3600
+    error_message = "download_url_ttl_seconds must be between 60 and 3600 seconds."
+  }
+}
+
+variable "enable_cost_protection" {
+  description = "Enable budgets and CloudWatch/SNS cost guardrails"
+  type        = bool
+  default     = true
+}
+
+variable "cost_alert_email" {
+  description = "Email to subscribe to cost/security alarms (optional, requires SNS confirmation)"
+  type        = string
+  default     = ""
+}
+
+variable "enable_sns_alert_topic" {
+  description = "Create SNS topic for alarm actions (requires sns:CreateTopic permissions)"
+  type        = bool
+  default     = false
+}
+
+variable "monthly_cost_budget_usd" {
+  description = "Monthly account budget in USD"
+  type        = number
+  default     = 25
+}
+
+variable "enable_aws_budgets" {
+  description = "Create AWS Budgets monthly budget resource (requires budgets permissions)"
+  type        = bool
+  default     = false
+}
+
+variable "monthly_cost_forecast_alert_threshold_percent" {
+  description = "Forecasted budget threshold percent for alerting"
+  type        = number
+  default     = 80
+}
+
+variable "api_4xx_alarm_threshold" {
+  description = "Alarm threshold for API 4xx count per period"
+  type        = number
+  default     = 200
+}
+
+variable "api_5xx_alarm_threshold" {
+  description = "Alarm threshold for API 5xx count per period"
+  type        = number
+  default     = 20
+}
+
+variable "api_request_count_alarm_threshold" {
+  description = "Alarm threshold for total API requests per period"
+  type        = number
+  default     = 5000
+}
+
+variable "lambda_errors_alarm_threshold" {
+  description = "Alarm threshold for Lambda errors per function per period"
+  type        = number
+  default     = 5
+}
+
+variable "lambda_throttles_alarm_threshold" {
+  description = "Alarm threshold for Lambda throttles per function per period"
+  type        = number
+  default     = 1
+}
+
+variable "alarm_period_seconds" {
+  description = "CloudWatch alarm period in seconds"
+  type        = number
+  default     = 300
+}
+
+variable "alarm_evaluation_periods" {
+  description = "CloudWatch alarm evaluation periods"
+  type        = number
+  default     = 1
+}
+
 variable "tags" {
   description = "Default tags applied to all resources"
   type        = map(string)


### PR DESCRIPTION
## Summary\n- restore API/Lambda/cost guardrail Terraform configuration and variables\n- keep sensitive JWT/email config sourced from AWS Secrets Manager via Terraform data objects\n- preserve bootstrap provisioning for deployer IAM + secret outputs\n\n## Validation\n- python compile checks passed for backend handlers and desktop app\n- terraform fmt -check and validate passed for infrastructure and bootstrap\n\n## Notes\n- local-only file infrastructure/terraform.tfvars is intentionally not included in this PR