### PR TITLE
docs: rebaseline sprint backlog and add Sprint 2 cost-impact review

### DIFF
--- a/docs/CLOUD_AGENT_BACKLOG.md
+++ b/docs/CLOUD_AGENT_BACKLOG.md
@@ -28,7 +28,49 @@ Use cloud agents to accelerate delivery while keeping scope small, testable, and
 
 - Sprint 1: Complete (issues #11, #12, #14, #26 closed)
 - Sprint 2: Complete (#13, #15, #16 delivered)
-- Closeout report: `docs/SPRINT_1_CLOSEOUT.md`
+- Closeout reports: `docs/SPRINT_1_CLOSEOUT.md`, `docs/SPRINT_2_CLOSEOUT.md`
+
+## User-Driven Rebaseline (Post Sprint 2)
+
+### Requested Product Direction
+- Persist selected folders as **managed folders** in desktop client.
+- Add explicit **Sync job** that uploads only new files from managed folders.
+- Keep cloud files when local files are deleted (no implicit cloud delete from sync).
+- Move output log into optional dialog (not always visible in main layout).
+- Add metadata extraction into `subjects` (date taken + geolocation when available).
+- Handle videos separately; for now videos should be excluded from upload.
+- Add deduplication so same image content uploads once even if present in multiple folders.
+- Improve desktop file-management view for large libraries.
+- Design low-cost original storage + fast preview strategy.
+- Auto-generate labels from folder hierarchy.
+
+### Sprint 3 (User Sync Foundation)
+1. Managed folder registry (persist/load/edit) in desktop app.
+2. Sync engine for new images in managed folders (no remote delete behavior).
+3. Video policy gate (detect and skip videos with explicit status/reporting).
+4. Metadata enrichment pipeline in desktop app:
+  - EXIF date taken to `subjects`
+  - geolocation token(s) to `subjects` when present
+  - folder hierarchy labels to `subjects`
+5. Output panel refactor to optional log dialog.
+
+### Sprint 4 (Scale + Cost Optimization)
+6. Content-based deduplication design and implementation (hash/fingerprint workflow).
+7. Desktop high-scale management view (bulk triage, large-list usability, performant filtering).
+8. Dual-object storage architecture:
+  - original image in lowest-cost acceptable storage tier
+  - preview derivative in fast-access tier for sub-second viewing
+9. Cost/performance benchmark for preview strategy and retrieval SLA.
+
+### Sprint 5 (Hardening + Policy)
+10. Sync observability and health dashboards (scan stats, upload/error rates, duplicate rate).
+11. Safe reindex/rebuild flow for managed-folder catalogs.
+12. Privacy controls for location metadata extraction (opt-in/opt-out + redaction policy).
+
+### Known Constraints / Decisions Needed
+- Dedup scope must be defined (per-user vs global).
+- Preview format/size policy must be defined before cost benchmark lock.
+- Geolocation metadata handling requires explicit privacy default.
 
 ### P0 (Do first)
 

--- a/docs/COST_ESTIMATE.md
+++ b/docs/COST_ESTIMATE.md
@@ -178,6 +178,33 @@ Year-over-year costs should remain stable at ~$94/month as photos age and shift 
 
 ---
 
+## Sprint 2 Incremental Cost Impact Review
+
+Sprint 2 shipped desktop queue/UX improvements and ops documentation. No new always-on AWS resources were introduced in Sprint 2, so fixed monthly infrastructure cost is effectively unchanged.
+
+### What changed operationally
+- Desktop queue features increase practical upload throughput and may increase total upload activity.
+- Retry/cancel controls reduce failed partial runs, but retries can temporarily increase request volume.
+- Ops playbook/checklist documentation has near-zero runtime infrastructure cost.
+
+### Incremental variable-cost model (per successful image upload)
+Approximate additional metered operations already used by current flow:
+- `POST /photos/upload-url` (API Gateway + Lambda + DynamoDB write)
+- `PUT` to S3 signed URL (S3 PUT request)
+- `POST /photos/upload-complete` (API Gateway + Lambda + DynamoDB update)
+
+Directional estimate for 100,000 successful uploads (us-east-1 style pricing assumptions):
+- S3 PUT requests: about $0.50
+- API Gateway requests (2 per upload): about $0.70
+- DynamoDB write/update units: about $0.25
+- Lambda invocation/compute for init+complete: typically low single-digit dollars or less at this scale
+
+### Practical conclusion
+- Sprint 2 cost delta is approximately **$0 in fixed baseline** and **low variable request costs** relative to storage.
+- The dominant long-term cost driver remains S3 storage footprint and chosen tiering strategy, not queue-control features.
+
+---
+
 ## What You Get
 
 ✅ Full-featured photo app (web + mobile + desktop clients)  

--- a/docs/SPRINT_3_PLAN.md
+++ b/docs/SPRINT_3_PLAN.md
@@ -1,0 +1,41 @@
+# Sprint 3 Plan (User Sync Foundation)
+
+## Goal
+Turn desktop uploads into a repeatable folder-sync workflow with metadata enrichment and clear operator UX.
+
+## Scope
+- Managed folders persist across app restarts.
+- Sync job uploads only newly discovered image files from managed folders.
+- Local deletes do not remove cloud copies.
+- Video files are detected and skipped with explicit queue/output status.
+- Output log becomes optional dialog (open on demand, not always visible).
+- Metadata enrichment sends additional `subjects` tokens:
+  - Date taken (when EXIF available)
+  - Geolocation token(s) (when EXIF GPS available)
+  - Folder hierarchy labels
+
+## Acceptance Criteria
+- User can add/remove managed folders and see them loaded after restart.
+- Running sync twice without file changes produces no duplicate uploads.
+- New files added under managed folders are uploaded on next sync.
+- Removed local files are not deleted from AWS.
+- Video files are not uploaded and appear as skipped in sync summary.
+- Output dialog can be opened/closed without affecting sync execution.
+- Subjects sent to backend include folder labels and available EXIF metadata.
+
+## Out of Scope
+- Backend hard-delete/reconcile behavior for local deletions.
+- Full dedup across cloud objects by content hash (planned Sprint 4).
+- AI image labeling.
+
+## Risks
+- EXIF parsing variability across file formats/devices.
+- Privacy concerns for geolocation metadata if default behavior is not explicit.
+- Folder scans may become slow on very large trees without indexing.
+
+## Suggested Implementation Order
+1. Managed folder persistence + sync command shell.
+2. Video exclusion + sync summary model.
+3. Output dialog refactor.
+4. Metadata extraction and folder-label subject generation.
+5. End-to-end regression pass on queue/sync interactions.


### PR DESCRIPTION
## Summary
- rebaseline backlog with user-driven roadmap for managed folders, sync, metadata enrichment, dedup, scalable UI, and storage strategy
- add dedicated Sprint 3 execution plan focused on managed-folder sync foundation
- add explicit Sprint 2 incremental cost impact review to cost documentation

## Why this change
- Aligns upcoming sprints to user-prioritized outcomes and records cost implications from completed Sprint 2 work.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (documentation and planning updates only)
- Rollback: Revert this PR