### PR TITLE
docs: lock dedupe/geolocation/preview policy decisions

### DIFF
--- a/docs/CLOUD_AGENT_BACKLOG.md
+++ b/docs/CLOUD_AGENT_BACKLOG.md
@@ -55,22 +55,23 @@ Use cloud agents to accelerate delivery while keeping scope small, testable, and
 5. Output panel refactor to optional log dialog.
 
 ### Sprint 4 (Scale + Cost Optimization)
-6. Content-based deduplication design and implementation (hash/fingerprint workflow).
+6. Content-based deduplication design and implementation (hash/fingerprint workflow, global across family users).
 7. Desktop high-scale management view (bulk triage, large-list usability, performant filtering).
 8. Dual-object storage architecture:
-  - original image in lowest-cost acceptable storage tier
-  - preview derivative in fast-access tier for sub-second viewing
+  - original image in lowest-cost acceptable storage tier (slow retrieval acceptable, including hours)
+  - preview derivative in fast-access tier sized for 4K viewing and responsive user experience
 9. Cost/performance benchmark for preview strategy and retrieval SLA.
 
 ### Sprint 5 (Hardening + Policy)
 10. Sync observability and health dashboards (scan stats, upload/error rates, duplicate rate).
 11. Safe reindex/rebuild flow for managed-folder catalogs.
-12. Privacy controls for location metadata extraction (opt-in/opt-out + redaction policy).
+12. Geolocation governance for mandatory metadata capture (retention, visibility, audit).
 
-### Known Constraints / Decisions Needed
-- Dedup scope must be defined (per-user vs global).
-- Preview format/size policy must be defined before cost benchmark lock.
-- Geolocation metadata handling requires explicit privacy default.
+### Decision Locks (2026-02-16)
+- Dedup scope: **global** across family users.
+- Geolocation metadata: store whenever present in image metadata; no disable toggle.
+- Preview policy: optimize for comfortable 4K display, not maximum fidelity.
+- Retrieval policy: high-resolution originals may use very slow/cheap storage (hours acceptable); previews should remain responsive and not painful to open.
 
 ### P0 (Do first)
 

--- a/docs/COST_ESTIMATE.md
+++ b/docs/COST_ESTIMATE.md
@@ -205,6 +205,30 @@ Directional estimate for 100,000 successful uploads (us-east-1 style pricing ass
 
 ---
 
+## Decision Update (2026-02-16) and Cost Direction
+
+### Locked Product Decisions
+- Deduplication scope is global across family users.
+- Geolocation metadata is always stored when present in image metadata.
+- Preview derivatives should be optimized for comfortable 4K display, not original-level fidelity.
+- High-resolution originals may use very slow/cheap storage with retrieval times that can be hours.
+
+### Expected Cost Effects
+- **Global dedupe** should reduce total stored GB and redundant request volume over time, especially for cross-family shared photos.
+- **Mandatory geolocation metadata** has negligible direct storage cost impact (small metadata footprint).
+- **Dual-tier image strategy** shifts cost from hot originals toward:
+  - cheaper archival classes for originals
+  - moderate fast-access storage + request cost for previews
+
+### Practical Modeling Guidance
+- Treat previews as primary interactive workload and size them for 4K-friendly viewing.
+- Treat originals as archival retrieval workload where long restore/download windows are acceptable.
+- Recalculate monthly cost with two buckets of bytes/requests:
+  - preview bytes + preview GET frequency
+  - original bytes + original retrieval frequency
+
+---
+
 ## What You Get
 
 ✅ Full-featured photo app (web + mobile + desktop clients)  

--- a/docs/SPRINT_3_PLAN.md
+++ b/docs/SPRINT_3_PLAN.md
@@ -11,7 +11,7 @@ Turn desktop uploads into a repeatable folder-sync workflow with metadata enrich
 - Output log becomes optional dialog (open on demand, not always visible).
 - Metadata enrichment sends additional `subjects` tokens:
   - Date taken (when EXIF available)
-  - Geolocation token(s) (when EXIF GPS available)
+  - Geolocation token(s) (when EXIF GPS available, always included)
   - Folder hierarchy labels
 
 ## Acceptance Criteria
@@ -22,6 +22,7 @@ Turn desktop uploads into a repeatable folder-sync workflow with metadata enrich
 - Video files are not uploaded and appear as skipped in sync summary.
 - Output dialog can be opened/closed without affecting sync execution.
 - Subjects sent to backend include folder labels and available EXIF metadata.
+- Geolocation metadata is persisted whenever present and cannot be disabled in settings.
 
 ## Out of Scope
 - Backend hard-delete/reconcile behavior for local deletions.
@@ -30,8 +31,12 @@ Turn desktop uploads into a repeatable folder-sync workflow with metadata enrich
 
 ## Risks
 - EXIF parsing variability across file formats/devices.
-- Privacy concerns for geolocation metadata if default behavior is not explicit.
+- Metadata quality variance for GPS precision/format across camera vendors.
 - Folder scans may become slow on very large trees without indexing.
+
+## Policy Locks
+- Deduplication is global (family-wide) and implemented in Sprint 4.
+- Geolocation metadata capture is mandatory when present in source image metadata.
 
 ## Suggested Implementation Order
 1. Managed folder persistence + sync command shell.


### PR DESCRIPTION
## Summary
- lock product decisions for global dedupe, mandatory geolocation capture, and preview/original retrieval policy
- align Sprint 3 and Sprint 4 planning docs to remove prior ambiguity
- update cost modeling guidance for dual-tier storage strategy under these decisions

## Why this change
- Captures user-confirmed policy decisions so implementation work proceeds with clear, stable requirements.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (docs and planning updates)
- Rollback: Revert this PR