### PR TITLE
desktop: enforce video skip policy in sync (closes #41)

### DIFF
--- a/desktop-client/README.md
+++ b/desktop-client/README.md
@@ -40,6 +40,7 @@ python app.py
 7. Use **List Photos** to retrieve your photos and paginate with `nextToken`.
 8. Select a row and click **Open Selected Image**.
 9. For folder sync, choose a folder, click **Add Managed Folder**, then click **Run Sync Job**.
+10. Videos detected during sync are marked as skipped and are not uploaded.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- detect video files during managed-folder sync scans
- mark videos as `SKIPPED_VIDEO` in queue with explicit reason
- report skipped-video counts in sync summary output
- keep image sync/upload behavior unchanged

## Why this change
- Sprint 3 issue #41 requires separate video handling with explicit skip reporting.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (desktop sync filtering update)
- Rollback: Revert this PR

Closes #41