### PR TITLE
docs: add Sprint 3 cost impact review

### DIFF
--- a/docs/COST_ESTIMATE.md
+++ b/docs/COST_ESTIMATE.md
@@ -229,6 +229,42 @@ Directional estimate for 100,000 successful uploads (us-east-1 style pricing ass
 
 ---
 
+## Sprint 3 Incremental Cost Impact Review
+
+Sprint 3 delivered managed-folder sync foundation, video-skip policy, and automatic subject enrichment (#39, #41, #40). These changes primarily affect variable request/storage patterns and do not add always-on infrastructure.
+
+### Fixed baseline impact
+- No new always-on AWS services were introduced.
+- Fixed monthly baseline remains approximately unchanged.
+
+### Variable-cost impact by shipped feature
+- **Managed-folder incremental sync (#39):**
+  - Can increase successful upload count because sync runs repeatedly as new files are discovered.
+  - Each successful image still follows existing metered flow: upload-init API + S3 PUT + upload-complete API.
+- **Video skip policy (#41):**
+  - Reduces variable cost growth by preventing video uploads in sync jobs.
+  - Avoids large-object S3 storage and PUT/request charges for skipped videos.
+- **Subject enrichment (#40):**
+  - Adds lightweight metadata (`Subjects`) to photo rows.
+  - Slightly increases DynamoDB item size; write/read cost can increase if item size crosses pricing boundaries.
+  - Geolocation/date/folder labels remain small compared to image-storage costs.
+
+### Net practical conclusion
+- Sprint 3 cost impact is still dominated by image upload volume and stored bytes, not control-plane logic.
+- Compared with pre-Sprint-3 behavior:
+  - costs may rise from higher image-sync throughput,
+  - costs may drop from video suppression,
+  - metadata overhead is typically minor.
+
+### Monitoring adjustments after Sprint 3
+- Track monthly counts for:
+  - sync-discovered images uploaded,
+  - videos skipped by policy,
+  - average DynamoDB item size for photo metadata.
+- Use these counters to separate growth due to real image intake vs metadata overhead.
+
+---
+
 ## What You Get
 
 ✅ Full-featured photo app (web + mobile + desktop clients)  

--- a/docs/SPRINT_3_PLAN.md
+++ b/docs/SPRINT_3_PLAN.md
@@ -34,6 +34,14 @@ Turn desktop uploads into a repeatable folder-sync workflow with metadata enrich
 - Metadata quality variance for GPS precision/format across camera vendors.
 - Folder scans may become slow on very large trees without indexing.
 
+## Cost Impact (Sprint 3)
+- Fixed AWS baseline: no major change expected (no new always-on services in scope).
+- Variable cost direction:
+  - image sync automation may increase successful image upload volume,
+  - video skip policy should reduce storage/request growth from large media,
+  - metadata enrichment adds small DynamoDB item-size overhead.
+- Overall expectation: storage and upload volume remain primary cost drivers; metadata overhead is secondary.
+
 ## Policy Locks
 - Deduplication is global (family-wide) and implemented in Sprint 4.
 - Geolocation metadata capture is mandatory when present in source image metadata.


### PR DESCRIPTION
## Summary
- add explicit Sprint 3 incremental cost-impact review to cost model
- add Sprint 3 cost-impact section to sprint plan for implementation visibility
- clarify fixed vs variable cost effects for #39, #41, and #40 scope

## Why this change
- Sprint 3 cost impacts were missing from the docs and review trail.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (documentation-only)
- Rollback: Revert this PR