### PR TITLE
docs: add Sprint 4 plan and Checkov sprint task

### DIFF
--- a/docs/CLOUD_AGENT_BACKLOG.md
+++ b/docs/CLOUD_AGENT_BACKLOG.md
@@ -28,7 +28,9 @@ Use cloud agents to accelerate delivery while keeping scope small, testable, and
 
 - Sprint 1: Complete (issues #11, #12, #14, #26 closed)
 - Sprint 2: Complete (#13, #15, #16 delivered)
-- Closeout reports: `docs/SPRINT_1_CLOSEOUT.md`, `docs/SPRINT_2_CLOSEOUT.md`
+- Sprint 3: Complete (#39, #40, #41 delivered)
+- Sprint 4: Planned (`docs/SPRINT_4_PLAN.md`)
+- Closeout reports: `docs/SPRINT_1_CLOSEOUT.md`, `docs/SPRINT_2_CLOSEOUT.md`, `docs/SPRINT_3_CLOSEOUT.md`
 
 ## User-Driven Rebaseline (Post Sprint 2)
 
@@ -61,6 +63,7 @@ Use cloud agents to accelerate delivery while keeping scope small, testable, and
   - original image in lowest-cost acceptable storage tier (slow retrieval acceptable, including hours)
   - preview derivative in fast-access tier sized for 4K viewing and responsive user experience
 9. Cost/performance benchmark for preview strategy and retrieval SLA.
+10. Implement Checkov for Terraform in CI with documented suppression policy.
 
 ### Sprint 5 (Hardening + Policy)
 10. Sync observability and health dashboards (scan stats, upload/error rates, duplicate rate).

--- a/docs/SPRINT_4_PLAN.md
+++ b/docs/SPRINT_4_PLAN.md
@@ -1,0 +1,63 @@
+# Sprint 4 Plan (Scale + Cost Optimization)
+
+## Goal
+Scale the system for larger family libraries while reducing redundant storage and strengthening Terraform security posture.
+
+## Scope
+- Global content-hash deduplication across family users.
+- High-scale desktop management view for large file sets.
+- Dual-tier storage architecture for originals vs previews.
+- Checkov implementation for Terraform static policy scanning in CI.
+
+## Workstreams
+
+### 1) Global Deduplication (Family-wide)
+- Define canonical content hash strategy (e.g., SHA-256 over normalized bytes).
+- Add dedupe lookup path before upload-init completion flow.
+- Ensure duplicate detections reference existing object rather than re-uploading.
+- Preserve folder labels and metadata references for all logical file entries.
+
+### 2) Scalable Desktop Library View
+- Improve list usability for large libraries (status triage, filtering, responsive updates).
+- Keep queue/sync operations responsive while large tables are visible.
+- Provide practical operator workflows for failures/skips/duplicates.
+
+### 3) Dual-Tier Storage Strategy
+- Keep originals in lowest-cost acceptable tier (slow retrieval acceptable).
+- Generate/store 4K-friendly preview derivatives in fast-access tier.
+- Define lifecycle and retrieval paths for preview-first UX.
+- Document fallback behavior when preview is unavailable.
+
+### 4) Terraform Security Scanning with Checkov
+- Add Checkov config/profile for Terraform directories.
+- Add CI step/job to run Checkov for infrastructure changes.
+- Define baseline policy for pass/fail and approved suppressions.
+- Document local and CI usage in deployment/security docs.
+
+## Acceptance Criteria
+- Duplicate images discovered across users upload once and are linked logically.
+- Desktop management workflows remain responsive at multi-thousand-item scale.
+- Preview opens are responsive for normal usage while originals may take longer to retrieve.
+- Checkov runs in CI on Terraform changes and blocks high-severity policy violations.
+- Any Checkov suppressions are explicit, justified, and documented.
+
+## Out of Scope
+- Full album collaboration feature set.
+- AI-based image classification.
+- Reworking all Terraform modules beyond policy-driven changes.
+
+## Risks
+- False-positive or noisy Checkov policies may initially slow merges.
+- Global dedupe requires careful ownership/reference integrity to avoid data mix-ups.
+- Preview generation/storage can increase request cost if derivative policy is oversized.
+
+## Suggested Implementation Order
+1. Checkov CI integration and baseline policy.
+2. Global dedupe core design + backend data model updates.
+3. Desktop scale-management view improvements.
+4. Preview/original dual-tier implementation and benchmark pass.
+
+## Validation Plan
+- Run compile/tests + Terraform fmt/validate + Checkov checks in CI.
+- Load-test dedupe and desktop list responsiveness on representative file sets.
+- Compare monthly cost metrics before/after Sprint 4 rollout.


### PR DESCRIPTION
## Summary
- create dedicated Sprint 4 plan document
- add Checkov Terraform implementation as explicit Sprint 4 deliverable
- update sprint status/backlog references to include Sprint 3 closeout and Sprint 4 planning state
- create tracking issue for Checkov implementation (#53)

## Why this change
- Establishes Sprint 4 execution plan and ensures Terraform security scanning is part of sprint scope.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (docs + issue tracking updates only)
- Rollback: Revert this PR