### PR TITLE
desktop+backend: global content-hash dedupe flow (closes #42)

### DIFF
--- a/backend/src/handlers/upload.py
+++ b/backend/src/handlers/upload.py
@@ -1,8 +1,10 @@
 import json
 import os
+import re
 from datetime import datetime, timezone
 
 import boto3
+from boto3.dynamodb.conditions import Attr
 
 s3 = boto3.client("s3")
 dynamodb = boto3.resource("dynamodb")
@@ -10,6 +12,7 @@ dynamodb = boto3.resource("dynamodb")
 PHOTO_BUCKET = os.environ["PHOTO_BUCKET"]
 PHOTOS_TABLE = os.environ["PHOTOS_TABLE"]
 MAX_SUBJECTS = 50
+CONTENT_HASH_PATTERN = re.compile(r"^[a-fA-F0-9]{64}$")
 
 
 def _sanitize_subjects(subjects):
@@ -40,6 +43,18 @@ def _sanitize_subjects(subjects):
 
     return deduped
 
+
+def _sanitize_content_hash(content_hash):
+    if content_hash is None:
+        return None
+    if not isinstance(content_hash, str):
+        return None
+
+    normalized = content_hash.strip().lower()
+    if not CONTENT_HASH_PATTERN.match(normalized):
+        return None
+    return normalized
+
 def handler(event, context):
     try:
         claims = (((event.get("requestContext") or {}).get("authorizer") or {}).get("jwt") or {}).get("claims") or {}
@@ -65,11 +80,18 @@ def handler(event, context):
         content_type = body.get("contentType", "image/webp")
         original_file_name = body.get("originalFileName")
         subjects = _sanitize_subjects(body.get("subjects"))
+        content_hash = _sanitize_content_hash(body.get("contentHash"))
 
         if body.get("subjects") is not None and subjects is None:
             return {
                 "statusCode": 400,
                 "body": json.dumps({"error": "subjects must be an array of strings"})
+            }
+
+        if body.get("contentHash") is not None and content_hash is None:
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "contentHash must be a 64-character hex SHA-256 string"})
             }
 
         if original_file_name:
@@ -81,9 +103,21 @@ def handler(event, context):
                 "body": json.dumps({"error": "photoId is required"})
             }
 
-        object_key = f"originals/{user_id}/{photo_id}.webp"
-
         table = dynamodb.Table(PHOTOS_TABLE)
+        dedupe_source = None
+        if content_hash:
+            dedupe_result = table.scan(
+                FilterExpression=Attr("ContentHash").eq(content_hash) & Attr("Status").eq("ACTIVE"),
+                ProjectionExpression="UserId, PhotoId, ObjectKey",
+                Limit=1,
+            )
+            dedupe_items = dedupe_result.get("Items") or []
+            if dedupe_items:
+                dedupe_source = dedupe_items[0]
+
+        object_key = dedupe_source.get("ObjectKey") if dedupe_source else f"originals/{user_id}/{photo_id}.webp"
+
+        status = "ACTIVE" if dedupe_source else "PENDING"
         item = {
             "UserId": user_id,
             "PhotoId": photo_id,
@@ -91,12 +125,29 @@ def handler(event, context):
             "ContentType": content_type,
             "OriginalFileName": original_file_name,
             "CreatedAt": datetime.now(timezone.utc).isoformat(),
-            "Status": "PENDING"
+            "Status": status
         }
         if subjects is not None:
             item["Subjects"] = subjects
+        if content_hash is not None:
+            item["ContentHash"] = content_hash
+        if dedupe_source:
+            item["DeduplicatedFromPhotoId"] = dedupe_source.get("PhotoId")
+            item["DeduplicatedFromUserId"] = dedupe_source.get("UserId")
 
         table.put_item(Item=item)
+
+        if dedupe_source:
+            return {
+                "statusCode": 200,
+                "body": json.dumps({
+                    "uploadRequired": False,
+                    "deduplicated": True,
+                    "objectKey": object_key,
+                    "linkedToPhotoId": dedupe_source.get("PhotoId"),
+                    "linkedToUserId": dedupe_source.get("UserId"),
+                })
+            }
 
         upload_url = s3.generate_presigned_url(
             "put_object",
@@ -111,6 +162,8 @@ def handler(event, context):
         return {
             "statusCode": 200,
             "body": json.dumps({
+                "uploadRequired": True,
+                "deduplicated": False,
                 "uploadUrl": upload_url,
                 "objectKey": object_key,
                 "expiresInSeconds": 900

--- a/desktop-client/README.md
+++ b/desktop-client/README.md
@@ -43,6 +43,7 @@ python app.py
 9. For folder sync, choose a folder, click **Add Managed Folder**, then click **Run Sync Job**.
 10. Videos detected during sync are marked as skipped and are not uploaded.
 11. Sync uploads add metadata subjects automatically (folder labels + EXIF date/geo when present).
+12. Sync reports duplicate detections and links duplicate content by hash without re-uploading bytes.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add content-hash validation and dedupe path in upload-init handler
- link duplicate uploads to existing active object without re-uploading bytes
- include upload response flags (`uploadRequired`, `deduplicated`) for client behavior
- preserve shared object safety in hard-delete by keeping object when other photo rows still reference it
- add desktop sync content hashing and duplicate-candidate reporting
- force serial sync upload mode when duplicate candidates are detected for deterministic dedupe linking
- add tests for upload dedupe and shared-object hard-delete safety

## Why this change
- Sprint 4 issue #42 requires global content-hash dedupe with user-visible duplicate reporting and no redundant object uploads.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [x] `terraform fmt -check -recursive`
- [x] `terraform validate`
- [x] `terraform plan` reviewed and attached/summarized
- [x] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Medium (upload-init and hard-delete behavior changed)
- Rollback: Revert this PR to restore pre-dedupe paths

## Notes
- Targeted tests executed locally:
  - `backend/tests/test_upload.py`
  - `backend/tests/test_hard_delete.py`

Closes #42