### PR TITLE
ci: support manual Checkov baseline runs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_checkov:
+        description: "Run Checkov Terraform scan regardless of changed files"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   terraform-changes:
@@ -136,7 +143,7 @@ jobs:
     name: Checkov Terraform security scan
     runs-on: ubuntu-latest
     needs: terraform-changes
-    if: needs.terraform-changes.outputs.terraform == 'true'
+    if: needs.terraform-changes.outputs.terraform == 'true' || (github.event_name == 'workflow_dispatch' && inputs.run_checkov)
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` trigger to CI Checks workflow
- add boolean input `run_checkov` for manual control
- allow Checkov job to run on manual dispatch even when Terraform files did not change

## Why this change
- Current Checkov job only runs when Terraform paths change, which prevents easy baseline scans.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (CI trigger logic only)
- Rollback: Revert this PR