### PR TITLE
docs: resequence upcoming sprints for budget-first Checkov work

### DIFF
--- a/docs/CLOUD_AGENT_BACKLOG.md
+++ b/docs/CLOUD_AGENT_BACKLOG.md
@@ -76,6 +76,41 @@ Use cloud agents to accelerate delivery while keeping scope small, testable, and
 - Preview policy: optimize for comfortable 4K display, not maximum fidelity.
 - Retrieval policy: high-resolution originals may use very slow/cheap storage (hours acceptable); previews should remain responsive and not painful to open.
 
+## Checkov Security Sprint Sequence (User Priority)
+
+### Next Sprint: Low-Cost Remediations First
+Target checks (budget-safe first wave):
+- `CKV2_AWS_61` (S3 lifecycle configuration)
+- `CKV_AWS_116` (Lambda DLQ)
+- `CKV2_AWS_57` (Secrets Manager rotation)
+
+Success criteria:
+- These controls are remediated with minimal cost impact.
+- Checkov baseline rerun confirms reduced finding count.
+- Cost impact notes are captured in sprint closeout.
+
+### Following Sprint: Controlled Skips + Governance
+Implement explicit, documented skips for:
+- `CKV_AWS_50` (Lambda X-Ray)
+- `CKV_AWS_18` (S3 access logging)
+
+Success criteria:
+- Suppressions are added with clear budget rationale and review owner.
+- Suppression policy is documented in security/deployment docs.
+- CI remains stable and transparent about skipped controls.
+
+### After Those Two Sprints: Revisit Remaining Checks
+Deferred checks to reassess with budget review:
+- `CKV_AWS_117` (Lambda in VPC)
+- `CKV_AWS_272` (Lambda code signing)
+- `CKV_AWS_173` (Lambda env var KMS)
+- `CKV_AWS_144` (S3 replication)
+- `CKV_AWS_145` (S3 KMS-by-default)
+- `CKV2_AWS_62` (S3 event notifications)
+
+Decision gate:
+- Re-evaluate security benefit vs monthly cost impact before implementation.
+
 ### P0 (Do first)
 
 1. Upload finalize flow (`upload-complete`) + pending/active states

--- a/docs/SPRINT_5_PLAN.md
+++ b/docs/SPRINT_5_PLAN.md
@@ -1,0 +1,30 @@
+# Sprint 5 Plan (Checkov Low-Cost Remediation)
+
+## Goal
+Reduce Checkov findings using the lowest-cost remediation set first, preserving budget headroom.
+
+## Scope
+- Remediate `CKV2_AWS_61` (S3 lifecycle configuration).
+- Remediate `CKV_AWS_116` (Lambda DLQ configuration).
+- Remediate `CKV2_AWS_57` (Secrets Manager automatic rotation).
+- Re-run Checkov baseline and capture delta.
+
+## Acceptance Criteria
+- Findings for `CKV2_AWS_61`, `CKV_AWS_116`, and `CKV2_AWS_57` are resolved.
+- CI Checkov job confirms reduced total failures.
+- Any infra additions include cost notes in PR body.
+- Sprint closeout includes variable/fixed cost impact summary.
+
+## Cost Guardrails
+- Prefer existing resources over new always-on services.
+- For DLQ, use right-sized queue policy and avoid unnecessary retention/storage overhead.
+- For rotation, keep schedule practical (not overly frequent) to control invocation/API costs.
+
+## Out of Scope
+- Remediation of high-cost checks (`CKV_AWS_144`, `CKV_AWS_145`, `CKV_AWS_117`).
+- Suppression policy rollout for skipped checks (handled in Sprint 6).
+
+## Validation Plan
+- Terraform fmt/validate + CI checks.
+- Manual Checkov run via workflow_dispatch (`run_checkov=true`).
+- Before/after findings table captured in sprint notes.

--- a/docs/SPRINT_6_PLAN.md
+++ b/docs/SPRINT_6_PLAN.md
@@ -1,0 +1,29 @@
+# Sprint 6 Plan (Checkov Suppression Governance)
+
+## Goal
+Introduce controlled, auditable skips for selected checks to protect budget while keeping security posture explicit.
+
+## Scope
+- Add explicit skip/suppression for `CKV_AWS_50` (Lambda X-Ray).
+- Add explicit skip/suppression for `CKV_AWS_18` (S3 access logging).
+- Document business justification, owner, and review cadence for each suppression.
+- Re-run Checkov baseline and confirm expected pass/fail profile.
+
+## Acceptance Criteria
+- `CKV_AWS_50` and `CKV_AWS_18` are suppressed with justification in config and docs.
+- Suppression entries include owner and next review date.
+- CI output remains clear on which checks are skipped and why.
+- Follow-up issue is created to reassess skipped checks at next budget review.
+
+## Cost Guardrails
+- No automatic enabling of X-Ray or S3 access logging in this sprint.
+- No hidden always-on services introduced by suppression implementation.
+- Keep suppression scope minimal (only the two approved checks).
+
+## Out of Scope
+- Re-evaluating high-cost checks in this sprint.
+- Implementing additional suppressions outside approved list.
+
+## Next Step After Sprint 6
+- Revisit remaining checks with fresh cost/security review:
+  - `CKV_AWS_117`, `CKV_AWS_272`, `CKV_AWS_173`, `CKV_AWS_144`, `CKV_AWS_145`, `CKV2_AWS_62`.


### PR DESCRIPTION
## Summary
- resequence upcoming sprints per user priority for Checkov work
- make next sprint a low-cost remediation sprint (CKV2_AWS_61, CKV_AWS_116, CKV2_AWS_57)
- make following sprint a controlled suppression sprint for CKV_AWS_50 and CKV_AWS_18
- add explicit revisit gate for remaining checks after those two sprints
- add Sprint 5 and Sprint 6 plan docs

## Why this change
- Aligns sprint execution to budget-first security remediation strategy.

## Validation
- [x] Local checks pass
- [x] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [ ] `terraform fmt -check -recursive`
- [ ] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [ ] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Low (planning/docs changes)
- Rollback: Revert this PR