### PR TITLE
Sprint 6: controlled Checkov skips with governance

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -146,6 +146,15 @@ Policy:
 - High/Critical findings fail checks by default.
 - Any suppression must use explicit `checkov:skip=` comment with a clear justification.
 
+Current approved suppressions (Sprint 6):
+- `CKV_AWS_50` (Lambda X-Ray) — owner: MillerPic Platform Team; next review: 2026-03-16.
+- `CKV_AWS_18` (S3 access logging) — owner: MillerPic Platform Team; next review: 2026-03-16.
+
+Governance:
+- Suppressions must include compensating controls in the inline reason.
+- Scope must remain limited to approved resources only.
+- Reassessment is required at the next monthly budget/security review.
+
 ### 5. Deploy Infrastructure
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,6 +32,15 @@ checkov --config-file .checkov.yml -d infrastructure -d infrastructure/bootstrap
 - Reason must include business/security context and compensating control when applicable.
 - Suppressions are reviewed in PR like any other security exception.
 
+### Active Suppressions (Sprint 6)
+
+| Check | Scope | Rationale | Compensating Controls | Owner | Next Review |
+| --- | --- | --- | --- | --- | --- |
+| `CKV_AWS_50` | Lambda functions in `infrastructure/lambda.tf` and bootstrap rotation Lambda in `infrastructure/bootstrap/main.tf` | X-Ray tracing deferred due recurring ingestion/storage cost for current family-scale workload | CloudWatch logs and alarms, Lambda DLQ, API error/throttle alarms | MillerPic Platform Team | 2026-03-16 |
+| `CKV_AWS_18` | S3 buckets `photos` and `terraform_state` | S3 access logging deferred to avoid additional storage/request cost this budget cycle | CloudTrail audit logs, S3 public access block, versioning, IAM least privilege | MillerPic Platform Team | 2026-03-16 |
+
+Suppression scope is intentionally limited to the two budget-approved checks above. Any new suppression requires explicit sprint planning approval.
+
 ---
 
 ## Authentication & Authorization

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -34,6 +34,7 @@ locals {
   app_sensitive_secret_name = "${var.project_name}/${var.environment}/app-sensitive-config"
 }
 
+#checkov:skip=CKV_AWS_18: Budget-approved exception for bootstrap/state bucket; S3 access logs deferred to avoid additional bucket + log retention cost. Compensating controls: CloudTrail and strict IAM on state resources. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_s3_bucket" "terraform_state" {
   bucket = local.state_bucket_name
 }
@@ -141,6 +142,7 @@ resource "aws_iam_role_policy" "app_sensitive_config_rotation" {
   })
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for low-volume secret rotation function. Compensating controls: CloudWatch logs + alarming and limited invocation path via Secrets Manager. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "app_sensitive_config_rotation" {
   function_name = "${var.project_name}-secret-rotation-${var.environment}"
   role          = aws_iam_role.app_sensitive_config_rotation.arn

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -120,6 +120,7 @@ resource "aws_iam_role_policy_attachment" "app_policy_attach" {
   policy_arn = aws_iam_policy.app_policy.arn
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "upload" {
   function_name                  = "${var.project_name}-upload-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -142,6 +143,7 @@ resource "aws_lambda_function" "upload" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "download" {
   function_name                  = "${var.project_name}-download-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -165,6 +167,7 @@ resource "aws_lambda_function" "download" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "list" {
   function_name                  = "${var.project_name}-list-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -187,6 +190,7 @@ resource "aws_lambda_function" "list" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "upload_complete" {
   function_name                  = "${var.project_name}-upload-complete-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -209,6 +213,7 @@ resource "aws_lambda_function" "upload_complete" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "delete" {
   function_name                  = "${var.project_name}-delete-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -231,6 +236,7 @@ resource "aws_lambda_function" "delete" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "trash" {
   function_name                  = "${var.project_name}-trash-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -253,6 +259,7 @@ resource "aws_lambda_function" "trash" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "hard_delete" {
   function_name                  = "${var.project_name}-hard-delete-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -275,6 +282,7 @@ resource "aws_lambda_function" "hard_delete" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "patch_photo" {
   function_name                  = "${var.project_name}-patch-photo-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -296,6 +304,7 @@ resource "aws_lambda_function" "patch_photo" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "search" {
   function_name                  = "${var.project_name}-search-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn
@@ -317,6 +326,7 @@ resource "aws_lambda_function" "search" {
   }
 }
 
+#checkov:skip=CKV_AWS_50: Budget-approved exception; X-Ray tracing deferred to avoid always-on trace ingestion/storage cost for family workload. Compensating controls: CloudWatch alarms/logs and DLQ coverage. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_lambda_function" "get_photo" {
   function_name                  = "${var.project_name}-get-photo-${var.environment}"
   role                           = aws_iam_role.lambda_exec.arn

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -2,6 +2,7 @@ locals {
   photo_bucket_name = "${var.s3_bucket_prefix}-${var.environment}"
 }
 
+#checkov:skip=CKV_AWS_18: Budget-approved exception for family-scale workload; access logs deferred to avoid recurring storage/request cost. Compensating controls: CloudTrail, CloudWatch alarms, versioning, public access block. Owner=MillerPic Platform Team; ReviewBy=2026-03-16.
 resource "aws_s3_bucket" "photos" {
   bucket = local.photo_bucket_name
 }


### PR DESCRIPTION
## Summary
- Implement Sprint 6 controlled Checkov suppressions for budget-approved checks only.
- Add inline Terraform suppressions for `CKV_AWS_50` (Lambda X-Ray) and `CKV_AWS_18` (S3 access logging).
- Record owner, compensating controls, and next review date in security/deployment docs.
- Create follow-up issue for monthly reassessment (#64).

## Why this change
- Executes Sprint 6 plan to keep CI stable while preserving cost guardrails.
- Makes exceptions explicit, auditable, and time-bound.

## Validation
- [x] Local checks pass
- [ ] Relevant endpoint flow tested
- [x] Backward compatibility considered

## Infrastructure checklist (if applicable)
- [x] `terraform fmt -check -recursive`
- [x] `terraform validate`
- [ ] `terraform plan` reviewed and attached/summarized
- [x] Rollback plan documented

## Security checklist
- [x] No secrets committed
- [x] Auth/authorization impact reviewed
- [x] IAM permissions least-privilege reviewed

## Risk & rollback
- Risk: Suppressions can mask future drift if not revisited on schedule.
- Rollback: Revert this PR to remove suppression comments and governance entries.

Closes #61