### PR TITLE
Bootstrap IAM: add CloudTrail read access for millerpic_tf

### DIFF
--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -373,6 +373,9 @@ resource "aws_iam_policy" "terraform_deployer" {
         Action = [
           "apigateway:*",
           "budgets:*",
+          "cloudtrail:DescribeTrails",
+          "cloudtrail:GetTrailStatus",
+          "cloudtrail:LookupEvents",
           "cloudwatch:*",
           "dynamodb:*",
           "ec2:DescribeSubnets",


### PR DESCRIPTION
## Summary
- Update bootstrap Terraform deployer policy to include minimal CloudTrail read actions:
  - cloudtrail:DescribeTrails
  - cloudtrail:GetTrailStatus
  - cloudtrail:LookupEvents

## Why
- millerpic_tf could operate core infrastructure but could not perform CloudTrail visibility checks during incident response.
- This adds read-only trail visibility without broadening write/admin CloudTrail permissions.

## Scope
- File changed: infrastructure/bootstrap/main.tf
- No apply/deploy performed.