### PR TITLE
Sprint 12 completion: bounded thumbnail caches and closeout evidence

### DIFF
--- a/desktop-client/thumbnail_hydration.py
+++ b/desktop-client/thumbnail_hydration.py
@@ -1,4 +1,5 @@
 LIST_THUMBNAIL_MAX_ATTEMPTS = 24
+LIST_THUMBNAIL_CACHE_MAX_ITEMS = 300
 
 
 def is_image_content_type(content_type):
@@ -36,3 +37,14 @@ def count_cached_rows(photos, bytes_cache):
         if photo_id and photo_id in cache:
             count += 1
     return count
+
+
+def cache_put_bounded(cache, key, value, max_items=LIST_THUMBNAIL_CACHE_MAX_ITEMS):
+    if cache is None or not key or value is None:
+        return
+
+    cache[key] = value
+    max_size = max(1, int(max_items or LIST_THUMBNAIL_CACHE_MAX_ITEMS))
+    while len(cache) > max_size:
+        oldest_key = next(iter(cache))
+        cache.pop(oldest_key, None)

--- a/docs/SPRINT_12_CLOSEOUT.md
+++ b/docs/SPRINT_12_CLOSEOUT.md
@@ -1,0 +1,42 @@
+# Sprint 12 Closeout - Desktop Thumbnail Performance (Closed)
+
+## Window
+- Planned duration: 120 minutes
+- Planned start: 2026-02-19 10:30 local
+- Planned end: 2026-02-19 12:30 local
+- Actual start: 2026-02-19 10:44:00 -05:00
+- Actual end: 2026-02-19 12:48:39 -05:00
+- Status: closed
+
+## Scope Completed
+1. Testability-first extraction for thumbnail hydration logic.
+   - Added pure helper module: `desktop-client/thumbnail_hydration.py`.
+   - Added automated unit tests: `desktop-client/tests/test_thumbnail_hydration.py`.
+
+2. Runtime thumbnail performance improvements.
+   - Concurrent thumbnail fetch pipeline retained in desktop list hydration.
+   - In-session thumbnail bytes cache reused during refresh and paging/search revisits.
+   - Cached resolved thumbnail download URLs to reduce repeated API lookups.
+
+3. Stability hardening.
+   - Added bounded cache helper with eviction to prevent unbounded in-memory growth.
+   - Applied bounded caching to both bytes cache and URL cache.
+
+## Validation Evidence
+- Desktop compile checks:
+  - `python -m py_compile desktop-client/app.py desktop-client/thumbnail_hydration.py`
+- Desktop unit tests:
+  - `pytest desktop-client/tests/test_thumbnail_hydration.py -q` => `5 passed`
+
+## Acceptance Criteria Mapping
+- Priority 1 extraction + tests runnable by Copilot: met.
+- List thumbnail hydration no longer sequential-only: met.
+- Repeated refreshes reuse session cache for same `photoId`: met.
+- Desktop app compiles cleanly after changes: met.
+- Existing list/label workflow preserved: met.
+
+## Known Risks / Carryover
+1. First-view latency still depends on network RTT and signed URL endpoint response time.
+2. Future hardening option: add telemetry counters for cache hit ratio and hydration elapsed time.
+
+Exit criteria met on 2026-02-19.

--- a/docs/SPRINT_12_PLAN.md
+++ b/docs/SPRINT_12_PLAN.md
@@ -1,5 +1,12 @@
 # Sprint 12 Plan - Desktop Thumbnail Performance
 
+## Sprint Window (Timestamped)
+- Planned duration: 120 minutes
+- Planned start: 2026-02-19 10:30 local
+- Planned end: 2026-02-19 12:30 local
+- Actual start: 2026-02-19 10:44:00 -05:00
+- Actual end: 2026-02-19 12:48:39 -05:00
+
 ## Goal Statement
 Reduce list-refresh latency in the desktop client so thumbnail-heavy pages become responsive enough for daily use.
 
@@ -56,3 +63,19 @@ Network RTT and signed-URL generation still affect first-load latency; optimizat
 - Desktop list thumbnails load concurrently with visible progressive improvement.
 - Cache reuse is active during the current app session.
 - Compile validation passes and closeout evidence is documented.
+
+## Execution Checkpoints
+- Sprint started: 2026-02-19 10:44:00 -05:00.
+- Checkpoint +45m: extracted thumbnail hydration helper + initial unit tests in place.
+- Checkpoint +90m: app wired to helper with concurrent fetch + bytes cache reuse.
+- Checkpoint +120m: bounded cache hardening for bytes and URL cache complete.
+- Sprint ended: 2026-02-19 12:48:39 -05:00.
+
+## Sprint 12 Checklist (Tracking)
+- [x] Extract pure thumbnail hydration candidate logic.
+- [x] Add automated tests for candidate/cache behaviors.
+- [x] Run concurrent thumbnail fetch pipeline.
+- [x] Reuse in-session thumbnail bytes cache on refresh.
+- [x] Add bounded cache guardrails to avoid unbounded growth.
+- [x] Add cached resolved download URLs for repeat fetch reduction.
+- [x] Compile + test validation evidence captured.


### PR DESCRIPTION
## Summary
- complete Sprint 12 runtime hardening for desktop thumbnail performance
- add bounded cache helper in `desktop-client/thumbnail_hydration.py`
- apply bounded cache writes for thumbnail bytes and resolved download URLs in `desktop-client/app.py`
- expand helper tests for bounded cache behavior in `desktop-client/tests/test_thumbnail_hydration.py`
- finalize Sprint 12 execution/checklist in `docs/SPRINT_12_PLAN.md`
- add final closeout evidence in `docs/SPRINT_12_CLOSEOUT.md`

## Validation
- `python -m py_compile desktop-client/app.py desktop-client/thumbnail_hydration.py`
- `pytest desktop-client/tests/test_thumbnail_hydration.py -q` => `5 passed`

## Issue
Closes #81